### PR TITLE
Add a Reimbursement flow to wpaustralia for ease of use and sanity

### DIFF
--- a/wp-content/plugins/wpaus-reimbursements/flamingo.php
+++ b/wp-content/plugins/wpaus-reimbursements/flamingo.php
@@ -1,0 +1,193 @@
+<?php
+namespace WPAustralia\Reimbursements\Flamingo;
+
+// Linkify links in flamingo lists.
+add_filter( 'flamingo_htmlize', 'make_clickable' );
+
+/**
+ * Add custom Statuses.
+ */
+function register_post_statuses() {
+	register_post_status( 'paid', array(
+		'post_type' => \Flamingo_Inbound_Message::post_type,
+		'label' => 'Paid',
+		'public' => true,
+		'show_in_admin_all_list' => true,
+		'show_in_admin_status_list' => true,
+	) );
+
+	register_post_status( 'approved', array(
+		'post_type' => \Flamingo_Inbound_Message::post_type,
+		'label' => 'Approved',
+		'public' => true,
+		'show_in_admin_all_list' => true,
+		'show_in_admin_status_list' => true,
+	) );
+
+	register_post_status( 'declined', array(
+		'post_type' => \Flamingo_Inbound_Message::post_type,
+		'label' => 'Declined',
+		'public' => true,
+		'show_in_admin_all_list' => true,
+		'show_in_admin_status_list' => true,
+	) );
+}
+add_action( 'flamingo_init', __NAMESPACE__ . '\register_post_statuses');
+
+/**
+ * Add the Approved/Declined/Paid statuses to the table filter.
+ */
+add_filter( 'views_flamingo_page_flamingo_inbound', function( $views ) {
+
+	// Overide the Inbox item to override the current class.
+	$count = \Flamingo_Inbound_Message::count([ 'post_status' => 'publish' ]);
+	$text = sprintf(
+		_nx(
+			'Inbox <span class="count">(%s)</span>',
+			'Inbox <span class="count">(%s)</span>',
+			$count, 'posts', 'wpaus'
+		),
+		number_format_i18n( $count )
+	);
+	$views['inbox'] = sprintf(
+		'<a href="%1$s"%2$s>%3$s</a>',
+		menu_page_url( 'flamingo_inbound', false ),
+		( ! isset( $_REQUEST['post_status'] ) ) ? ' class="current"' : '',
+		$text
+	);
+
+	$count = \Flamingo_Inbound_Message::count([ 'post_status' => 'approved' ]);
+	$text = sprintf(
+		_nx(
+			'Approved <span class="count">(%s)</span>',
+			'Approved <span class="count">(%s)</span>',
+			$count, 'posts', 'wpaus'
+		),
+		number_format_i18n( $count )
+	);
+	$views['approved'] = sprintf(
+		'<a href="%1$s"%2$s>%3$s</a>',
+		add_query_arg( ['post_status' => 'approved'], menu_page_url( 'flamingo_inbound', false ) ),
+		( isset( $_REQUEST['post_status'] ) && 'approved' === $_REQUEST['post_status'] ) ? ' class="current"' : '',
+		$text
+	);
+
+	$count = \Flamingo_Inbound_Message::count([ 'post_status' => 'paid' ]);
+	$text = sprintf(
+		_nx(
+			'Paid <span class="count">(%s)</span>',
+			'Paid <span class="count">(%s)</span>',
+			$count, 'posts', 'wpaus'
+		),
+		number_format_i18n( $count )
+	);
+	$views['paid'] = sprintf(
+		'<a href="%1$s"%2$s>%3$s</a>',
+		add_query_arg( ['post_status' => 'paid'], menu_page_url( 'flamingo_inbound', false ) ),
+		( isset( $_REQUEST['post_status'] ) && 'paid' === $_REQUEST['post_status'] ) ? ' class="current"' : '',
+		$text
+	);
+
+	$count = \Flamingo_Inbound_Message::count([ 'post_status' => 'declined' ]);
+	$text = sprintf(
+		_nx(
+			'Declined <span class="count">(%s)</span>',
+			'Declined <span class="count">(%s)</span>',
+			$count, 'posts', 'wpaus'
+		),
+		number_format_i18n( $count )
+	);
+	$views['declined'] = sprintf(
+		'<a href="%1$s"%2$s>%3$s</a>',
+		add_query_arg( ['post_status' => 'declined'], menu_page_url( 'flamingo_inbound', false ) ),
+		( isset( $_REQUEST['post_status'] ) && 'declined' === $_REQUEST['post_status'] ) ? ' class="current"' : '',
+		$text
+	);
+
+	return $views;
+});
+
+/**
+ * Allow filtering to approved/declined/paid
+ */
+add_filter( 'pre_get_posts', function( $query ) {
+	if (
+		is_admin() &&
+		isset( $_GET['page'] ) && 'flamingo_inbound' === $_GET['page'] &&
+		( empty( $query->query['post_status'] ) || 'any' === $query->query['post_status'] )
+	) {
+		if ( \Flamingo_Inbound_Message::post_type === $query->query['post_type'] ) {
+			$query->query['post_status'] = $query->query_vars['post_status'] = $_REQUEST['post_status'] ?? 'publish';
+		}
+	}
+});
+
+/**
+ * Save additional approved/declined/paid statuses.
+ */
+add_action( 'load-flamingo_page_flamingo_inbound', function() {
+	if (
+		'save' == flamingo_current_action() &&
+		! empty( $_REQUEST['post'] ) &&
+		! empty( $_POST['inbound']['status'] )
+	) {
+		$post = get_post( $_REQUEST['post'] );
+
+		if ( ! $post )
+			return;
+
+		if ( ! current_user_can( 'flamingo_edit_inbound_message', $post->ID ) )
+			wp_die( __( 'You are not allowed to edit this item.', 'flamingo' ) );
+
+		check_admin_referer( 'flamingo-update-inbound_' . $post->ID );
+
+		$status = $_POST['inbound']['status'];
+
+		if ( $status != get_post_status( $post->ID ) ) {
+			wp_update_post([
+				'ID' => $post->ID,
+				'post_status' => $status
+			]);
+		}
+	}
+}, 9 );
+
+/**
+ * Add the extra statuses to the Submit box.
+ */
+add_action( 'load-flamingo_page_flamingo_inbound', function() {
+	if ( 'edit' == flamingo_current_action() ) {
+		add_meta_box(
+			'submitdiv', __( 'Status', 'flamingo' ),
+			function( $post ) {
+				ob_start();
+				\flamingo_inbound_submit_meta_box( $post );
+				$output = ob_get_clean();
+
+				$statuses = [];
+				$status   = get_post_status( $post->id );
+				if ( 'publish' === $status ) {
+					$status = 'ham';
+				}
+
+				// The statuses we need.
+				foreach ( [
+					'ham' => 'Inbox',
+					'approved' => 'Approved',
+					'declined' => 'Declined',
+					'paid' => 'Paid',
+					'spam' => 'Spam'
+				] as $value => $text ) {
+					$statuses[] = '<label><input type="radio" ' . checked( $status, $value, false ) . ' name="inbound[status]" value="' . $value . '">' . $text . '</label>';
+				}
+
+				echo preg_replace(
+					'!(<fieldset.+?>).+(</fieldset>)!is',
+					'$1' . implode( '<br>', $statuses ) . '$2',
+					$output
+				);
+			},
+			null, 'side', 'core'
+		);
+	}
+});

--- a/wp-content/plugins/wpaus-reimbursements/plugin.php
+++ b/wp-content/plugins/wpaus-reimbursements/plugin.php
@@ -1,0 +1,14 @@
+<?php
+namespace WPAustralia\Reimbursements;
+/**
+ * Plugin Name: WP Australia Reimbursements
+ * Description: Expands upon Contact Form 7 & Flamingo to add reimbursement flow/etc.
+ */
+
+if ( ! class_exists( 'WPCF7_Submission' ) ) return;
+if ( ! defined( 'FLAMINGO_VERSION' ) ) return;
+
+include __DIR__ . '/wpcf7.php'; // For contact form integrations.
+include __DIR__ . '/flamingo.php'; // For admin integration.
+include __DIR__ . '/xero.php'; // For Xero integration.
+include __DIR__ . '/public-shortcode.php'; // To provide a public log of approved/paid reimbursement transactions

--- a/wp-content/plugins/wpaus-reimbursements/public-shortcode.php
+++ b/wp-content/plugins/wpaus-reimbursements/public-shortcode.php
@@ -1,0 +1,79 @@
+<?php
+namespace WPAustralia\Reimbursements\PublicShortcode;
+
+function reimbursement_listing_shortcode() {
+	ob_start();
+
+	$items = get_items();
+	echo '<ol>';
+	foreach ( $items as $item ) {
+		printf(
+			"<li>On <em>%s</em> <em>%s</em> requested <strong>$%s</strong> for the <em>%s</em> meetup held on <em>%s</em> for <em>%s</em> - <strong>%s</strong></li>",
+			gmdate( 'j F Y', strtotime( $item->when ) ),
+			$item->who,
+			number_format_i18n( $item->cost, 2 ),
+			$item->for[0],
+			gmdate( 'j F Y', strtotime( $item->for[1] ) ),
+			implode( ', ', array_map( function( $text ) {
+				// Remove any account prefixes, ie. 'FOOD - ', we only want descriptions.
+				return preg_replace( '!^[A-Z-]+ - (.+)$!', '$1', $text );
+			}, $item->what ) ),
+			ucwords( $item->status )
+		);
+	}
+	echo '</ol>';
+
+	return ob_get_clean();
+}
+add_shortcode( 'reimbursement-lisitng', __NAMESPACE__ . '\reimbursement_listing_shortcode' );
+
+function get_items() {
+	// TODO: Should somehow get sponsor invoices into this set of data?
+
+	$items    = [];
+	$messages = \Flamingo_Inbound_Message::find([
+		'posts_per_page' => 999,
+		'channel' => 'reimbursement-request',
+		'post_status' => [ 'publish', 'approved', 'declined', 'paid' ],
+	]);
+
+	foreach ( $messages as $m ) {
+		$status = 'Pending Review';
+		switch ( get_post_status( $m->id ) ) {
+			case 'publish':
+				$status = 'Pending Review';
+			break;
+			case 'approved':
+				$status = 'Pending Reimbursement';
+				break;
+			case 'declined':
+			case 'paid':
+				$status = ucwords( get_post_status( $m->id ) );
+				break;
+		}
+
+		$items[] = (object) [
+			'who'  => $m->fields['your-name'],
+			'when' => get_post_field( 'post_date', $m->id ),
+			'for'  => [ $m->fields['meetup'], $m->fields['date'] ],
+			'what' => array_unique( array_filter( [
+				$m->fields['category-one'],
+				$m->fields['category-two'] ?? false, 
+				$m->fields['category-three'] ?? false,
+				$m->fields['category-four'] ?? false,
+				$m->fields['category-five'] ?? false,
+			] ) ),
+			'cost' => array_sum( [
+				$m->fields['cost-one'],
+				$m->fields['cost-two'] ?? 0.00, 
+				$m->fields['cost-three'] ?? 0.00,
+				$m->fields['cost-four'] ?? 0.00,
+				$m->fields['cost-five'] ?? 0.00,
+			] ),
+			'status' => $status,
+		];
+
+	}
+
+	return $items;
+}

--- a/wp-content/plugins/wpaus-reimbursements/wpcf7.php
+++ b/wp-content/plugins/wpaus-reimbursements/wpcf7.php
@@ -1,0 +1,91 @@
+<?php
+namespace WPAustralia\Reimbursements\CF7;
+
+/**
+ * Filter out the extra file fields when not in use.
+ */
+function wpcf7_posted_data( $data ) {
+	foreach ( [ '-one', '-two', '-three', '-four', '-five' ] as $field_suffix ) {
+		$matching_fields = [];
+		foreach ( $data as $field => $field_data ) {
+			if ( substr( $field, -1*strlen( $field_suffix ) ) === $field_suffix ) {
+				$matching_fields[ $field ] = $field_data;
+			}
+		}
+
+		// If all are empty. unset.
+		$empty = array_filter( $matching_fields, function( $item ) {
+			return !empty( $item ) && $item !== '0.00';
+		} );
+		if ( ! $empty ) {
+			foreach ( array_keys( $matching_fields ) as $k ) {
+				unset( $data[ $k ] );
+			}
+		}
+	}
+
+	return $data;
+}
+add_filter( 'wpcf7_posted_data', __NAMESPACE__ . '\wpcf7_posted_data' );
+
+/**
+ * CF7 deletes the files shortly after this action..
+ * Store them for later use.
+ */
+function wpcf7_mail_sent( $contact_form ) {
+	// "Copy" any uploaded files to tmp
+	$uploaded_files = \WPCF7_Submission::get_instance()->uploaded_files();
+
+	// ie. Put it back in $_FILES after move_uploaded_file() stole it.
+	foreach ( $uploaded_files as $form_field => $file ) {
+		$tmp_file = tempnam( sys_get_temp_dir(), 'reimbursement-' );
+
+		if ( copy( $file, $tmp_file ) ) {
+			$_FILES[ $form_field ]['tmp_name'] = $tmp_file;
+		}
+	}
+}
+add_action( 'wpcf7_mail_sent', __NAMESPACE__ . '\wpcf7_mail_sent' );
+
+
+/**
+ * Attach files to the Flamingo message.
+ */
+function wpcf7_after_flamingo( $result ) {
+	if ( empty( $result['flamingo_inbound_id'] ) ) {
+		return;
+	}
+
+	$stored_message = new \Flamingo_Inbound_Message( $result['flamingo_inbound_id'] );
+	$uploaded_files = \WPCF7_Submission::get_instance()->uploaded_files();
+
+	if ( $uploaded_files ) {
+		$upload_dir         = wp_upload_dir();
+		$reimbursements_dir = $upload_dir['basedir'] . '/reimbursements';
+		$reimbursements_url = $upload_dir['baseurl'] . '/reimbursements';
+
+		wp_mkdir_p( $reimbursements_dir );
+		if ( ! file_exists( "{$reimbursements_dir}/index.html" ) ) {
+			@touch( "{$reimbursements_dir}/index.html" );
+		}
+
+		foreach ( $uploaded_files as $form_field => $file ) {
+			$name = sprintf( "%s-%s-%s",
+				gmdate( 'Ymd' ),
+				wp_generate_password( 8, false ),
+				wp_basename( $file )
+			);
+			$name = wp_unique_filename( $reimbursements_dir, $name );
+
+			if ( rename( $_FILES[ $form_field ]['tmp_name'], "{$reimbursements_dir}/{$name}" ) ) {
+				@chmod( "{$reimbursements_dir}/{$name}", 0666 );
+
+				$stored_message->fields[ $form_field ] = "{$reimbursements_url}/{$name}";
+			}
+		}
+
+		$stored_message->save();
+	}
+
+}
+add_action( 'wpcf7_after_flamingo', __NAMESPACE__ . '\wpcf7_after_flamingo' );

--- a/wp-content/plugins/wpaus-reimbursements/xero-functions.php
+++ b/wp-content/plugins/wpaus-reimbursements/xero-functions.php
@@ -1,6 +1,9 @@
 <?php
 namespace WPAustralia\Reimbursements\Xero;
 
+/**
+ * Generate a Xero oAuth login url.
+ */
 function get_oauth_link( $back_to = '' ) {
 	if ( ! $back_to ) {
 		$back_to = $_SERVER['REQUEST_URI'];
@@ -23,6 +26,9 @@ function get_oauth_link( $back_to = '' ) {
 	return $url;
 }
 
+/**
+ * Retrieve the stored Xero tokens.
+ */
 function get_token() {
 	$token = get_user_meta( get_current_user_id(), '_wpaus_xero', true );
 	if ( $token && $token['expiration'] > time() ) {
@@ -59,11 +65,18 @@ function refresh_token( $token ) {
 }
 
 
-// Xero API as a specific Tenant ID.
+/**
+ * Make a Xero API call with a specific Tenant ID specified.
+ */
 function xero_api_t( $tenant, $endpoint, $payload = false, $headers = [], $method = null ) {
 	return xero_api( $endpoint, $payload, $headers, $method, $tenant );
 }
 
+/**
+ * A super simple Xero API endpoint wrapper.
+ *
+ * If `$tenant` isn't specified, it uses the first known tenant by `get_token()`, assuming it's connected to a single Xero install.
+ */
 function xero_api( $endpoint, $payload = false, $headers = [], $method = null, $tenant = false ) {
 
 	if ( is_null( $method ) ) {

--- a/wp-content/plugins/wpaus-reimbursements/xero-functions.php
+++ b/wp-content/plugins/wpaus-reimbursements/xero-functions.php
@@ -1,0 +1,129 @@
+<?php
+namespace WPAustralia\Reimbursements\Xero;
+
+function get_oauth_link( $back_to = '' ) {
+	if ( ! $back_to ) {
+		$back_to = $_SERVER['REQUEST_URI'];
+	}
+
+	$url = 'https://login.xero.com/identity/connect/authorize?response_type=code' . 
+		'&client_id=' . WPAUS_XERO_CLIENTID .
+		'&redirect_uri=' . admin_url( 'admin-ajax.php?action=xero_oauth_callback' ) . 
+		'&scope=' . implode( ' ', [
+			'accounting.transactions',  // For invoice creation
+			'accounting.attachments',   // ..to attach files to the invoice, not 'files'
+			'accounting.settings.read', // To be able to read the Organisation name..
+			'offline_access'            // To be able to refresh the access_token since Xero fails to unlink apps when it expires and has no re-auth flow. "Beta"
+		] ) .
+		'&state=' . urlencode( json_encode( [
+			'nonce'   => wp_create_nonce( 'xero' ),
+			'back_to' => $back_to, // Passing through state, as Xero requires the redirect_uri to match exactly.. no context?
+		]) );
+
+	return $url;
+}
+
+function get_token() {
+	$token = get_user_meta( get_current_user_id(), '_wpaus_xero', true );
+	if ( $token && $token['expiration'] > time() ) {
+		return $token;
+	}
+
+	if ( $token && $token['refresh_token'] ) {
+		return refresh_token( $token );
+	}
+
+	return false;
+}
+
+/**
+* Since Xero doesn't handle oAuth2 apps access_tokens expiring
+* (No really, it expires, but you have to manually disconnect to reconnect..)
+*/
+function refresh_token( $token ) {
+	$json = xero_api( 'connect/token', [
+		'grant_type'    => 'refresh_token',
+		'refresh_token' => $token['refresh_token']
+	] );
+
+	if ( $json ) {
+		$token['access_token']  = $json->access_token;
+		$token['token_type']    = $json->token_type;
+		$token['expiration']    = time() + $json->expires_in;
+		$token['refresh_token'] = $json->refresh_token;
+
+		update_user_meta( get_current_user_id(), '_wpaus_xero', $token );
+	}
+
+	return $token;
+}
+
+
+// Xero API as a specific Tenant ID.
+function xero_api_t( $tenant, $endpoint, $payload = false, $headers = [], $method = null ) {
+	return xero_api( $endpoint, $payload, $headers, $method, $tenant );
+}
+
+function xero_api( $endpoint, $payload = false, $headers = [], $method = null, $tenant = false ) {
+
+	if ( is_null( $method ) ) {
+		$method = $payload ? 'POST' : 'GET';
+	}
+
+	$base_url = 'https://api.xero.com/';
+
+	if ( 'connections' === $endpoint ) {
+		$tenant = false; // This endpoint returns the tenants
+	} elseif ( 'connect/token' === $endpoint ) {
+		// Different host
+		$base_url = 'https://identity.xero.com/';
+		// Needs Basic auth
+		$auth = 'BASIC ' . base64_encode( WPAUS_XERO_CLIENTID . ':' . WPAUS_XERO_SECRET );
+		// Without tenants specified.
+		$tenant = false;
+	} else {
+		// Actual rest-api endpoint?
+		$base_url .= 'api.xro/2.0/';
+	}
+
+	// Only fetch the token details when needed..
+	if ( ! isset( $auth ) || ! isset( $tenant ) ) {
+		$token = get_token();
+		$auth = 'Bearer ' . $token['access_token'];
+	
+		// Fall back to the first we find.
+		if ( ! isset( $tenant ) ) {
+			$tenant = array_keys( $token['organisations'] )[0];
+		}
+	}
+
+	$args = [
+		'method'       => $method,
+		'body'         => $payload,
+		'redirection'  => 0,
+		'headers'      => array_merge(
+			[
+				'Authorization' => $auth,
+				'Accept'        => 'application/json',
+			],
+			'POST' === $method && ! isset( $headers['Content-Type' ] ) && is_string( $payload ) && '{' == substr( $payload, 0, 1 ) ? [ 'Content-Type' => 'application/json' ] : [],
+			$tenant ? [ 'Xero-tenant-id' => $tenant ] : [],
+			$headers
+		),
+	];
+
+	$resp = wp_remote_request( $base_url . $endpoint, $args );
+
+	$code = wp_remote_retrieve_response_code( $resp );
+	if (
+		$code >= 200 && $code < 300 &&
+		( $json = json_decode( wp_remote_retrieve_body( $resp ) ) )
+	) {
+		return $json;
+	}
+
+	//var_dump( $args, $resp );
+	wp_die( wp_remote_retrieve_body( $resp ) );
+
+	return false;
+}

--- a/wp-content/plugins/wpaus-reimbursements/xero.php
+++ b/wp-content/plugins/wpaus-reimbursements/xero.php
@@ -1,0 +1,24 @@
+<?php
+namespace WPAustralia\Reimbursements\Xero;
+
+/**
+ * Add the Import to Xero metabox.
+ */
+add_action( 'load-flamingo_page_flamingo_inbound', function() {
+	if ( 'edit' != flamingo_current_action() ) {
+		return;
+	}
+
+	add_meta_box( 'xerodiv', __( 'Xero', 'flamingo' ), __NAMESPACE__ . '\meta_box', null, 'side', 'core' );
+} );
+
+function meta_box( $post ) {
+	echo 'Work In Progress. Not implemented.<br>';
+	echo '<button>Import to Xero</button>';
+
+// Xero OAuth2
+// WPAUS_XERO_CLIENTID
+// WPAUS_XERO_SECRET
+
+}
+

--- a/wp-content/plugins/wpaus-reimbursements/xero.php
+++ b/wp-content/plugins/wpaus-reimbursements/xero.php
@@ -117,8 +117,12 @@ function create_bill() {
 		wp_die( "Something is MIA." );
 	}
 
-	// First word of the meetup group.
-	$meetup = preg_replace( '!^(\S+).*$!', '$1', $message->fields['meetup'] );
+	// First word of the meetup group.. kinda.. :)
+	// 'Port Macquarie' and 'Gold Coast' should be full minus the space, this hacky min-5char + extra non-space chars.
+	$meetup = str_replace( ' ', '',
+		preg_replace( '!^(.{5}\S*).*$!', '$1', $message->fields['meetup'] )
+	);
+	// Xero is prefixed with WP-, prefix if it's not already done.
 	if ( 'WP-' != substr( $meetup, 0, 3 ) ) {
 		$meetup = "WP-{$meetup}";
 	}

--- a/wp-content/plugins/wpaus-reimbursements/xero.php
+++ b/wp-content/plugins/wpaus-reimbursements/xero.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPAustralia\Reimbursements\Xero;
 
+include __DIR__ . '/xero-functions.php';
+
 /**
  * Add the Import to Xero metabox.
  */
@@ -12,13 +14,294 @@ add_action( 'load-flamingo_page_flamingo_inbound', function() {
 	add_meta_box( 'xerodiv', __( 'Xero', 'flamingo' ), __NAMESPACE__ . '\meta_box', null, 'side', 'core' );
 } );
 
+/**
+ * The Metabox template.
+ */
 function meta_box( $post ) {
-	echo 'Work In Progress. Not implemented.<br>';
-	echo '<button>Import to Xero</button>';
+	$token = get_token();
 
-// Xero OAuth2
-// WPAUS_XERO_CLIENTID
-// WPAUS_XERO_SECRET
+	$invoices = get_post_meta( $post->id, '_xero_invoice', true );
 
+	if ( $token ) {
+		foreach ( $token['organisations'] as $org ) {
+			echo '<h3>' . esc_html( $org['name'] ) . '</h3>';
+
+			if ( isset( $invoices[ $org['id'] ] ) ) {
+				printf(
+					'<p><strong>Xero Invoice:</strong> <a href="%s">%s</a></p>',
+					'https://go.xero.com/AccountsPayable/Edit.aspx?InvoiceID=' . $invoices[ $org['id'] ],
+					$invoices[ $org['id'] ]
+				);
+			} else {
+				// Import it?
+				$import_url = wp_nonce_url(
+					add_query_arg(
+						[
+							'action'    => 'xero_create_bill',
+							'post_id'   => $post->id,
+							'tenant_id' => $org['id'],
+						],
+						admin_url( 'admin-ajax.php' )
+					),
+					'xero_bill'
+				);
+				printf(
+					'<p><a href="%s" class="button">%s</a></p>',
+					esc_url( $import_url ),
+					sprintf(
+						'Create draft Bill on %s',
+						esc_html( $org['name'] )
+					)
+				);
+			}
+		}
+	} else if ( $invoices ) {
+		// This is shitty UX..
+		foreach ( $invoices as $tenant => $invoice ) {
+			printf(
+				'<h3>%s</h3><p><strong>Xero Invoice:</strong> <a href="%s">%s</a></p>',
+				esc_html( $invoice['org'] ),
+				esc_url( 'https://go.xero.com/AccountsPayable/Edit.aspx?InvoiceID=' . $invoice['id'] ),
+				esc_html( $invoice['id'] )
+			);
+		}
+	}
+
+	echo '<h3>Manage Connection</h3>';
+	if ( $token ) {
+		echo '<p><a href="' . esc_url( get_oauth_link() ) . '" class="button button-secondary">reConnect to Xero</a></p>';
+		echo '<p><a href="' . esc_url( wp_nonce_url( admin_url( 'admin-ajax.php?action=xero_forget' ), 'xero_forget' ) ) . '" class="button button-secondary">Forget Connection</a></p>';
+	} else {
+		echo '<p><a href="' . esc_url( get_oauth_link() ) . '" class="button">Connect to Xero</a></p>';
+	}
+	echo '<p><a href="https://apps.xero.com/au/connected" class="button button-secondary">Manage Connected Apps</a></p>';
 }
 
+/**
+ * "Forget" the locally stored details.
+ */
+function forget_me() {
+	check_admin_referer( 'xero_forget' );
+
+	delete_user_meta( get_current_user_id(), '_wpaus_xero' );
+
+	header( 'Content-Type: text/html' );
+	_default_wp_die_handler(
+		'<h1>Your Xero details have been removed.</h1>' .
+		'<p>You should now disconnect the WP Australia app from your Xero Account.<p>' .
+		'<p><a href="https://apps.xero.com/au/connected" class="button button-secondary">Manage Connected Apps</a></p>'
+	);
+}
+add_action( 'wp_ajax_xero_forget', __NAMESPACE__ . '\forget_me' );
+
+/**
+ * Create the Bill in Xero.
+ */
+function create_bill() {
+	if ( ! isset( $_GET['_wpnonce'], $_GET['post_id'], $_GET['tenant_id'] ) ) {
+		wp_die( "Invalid Request." );
+	}
+
+	check_admin_referer( 'xero_bill' );
+
+	$token   = get_token();
+	$tenant  = $_GET['tenant_id'];
+	$message = new \Flamingo_Inbound_Message( $_GET['post_id'] );
+	if ( ! $token || ! $tenant || ! $message ) {
+		wp_die( "Something is MIA." );
+	}
+
+	// First word of the meetup group.
+	$meetup = preg_replace( '!^(\S+).*$!', '$1', $message->fields['meetup'] );
+	if ( 'WP-' != substr( $meetup, 0, 3 ) ) {
+		$meetup = "WP-{$meetup}";
+	}
+	$tracking = [
+		[ 'Name' => 'Area', 'Option' => 'WP-Aust' ],
+		[ 'Name' => 'SubArea', 'Option' => $meetup ]
+	];
+
+	// Build the Bill. 
+	$payload = [
+		'Type'    => 'ACCPAY',
+		'Contact' => [
+			'Name' => $message->from_name,
+			'EmailAddress' => $message->from_email,
+		],
+		'Date' => gmdate( 'Y-m-d', strtotime( $message->fields['date'] ) ?: time() ),
+		'DueDate' => gmdate( 'Y-m-d', strtotime( '+3 weeks' ) ),
+		'LineAmountTypes' => 'Inclusive',
+		'Status' => 'DRAFT',
+		'LineItems' => []
+	];
+
+	$files_to_upload = array();
+	foreach ( [ '-one', '-two', '-three', '-four', '-five' ] as $field_suffix ) {
+		// Empty ones were stripped out already.
+		$fields = [];
+		foreach ( $message->fields as $field => $field_data ) {
+			if ( substr( $field, -1*strlen( $field_suffix ) ) === $field_suffix ) {
+				$fields[ substr( $field, 0, -1*strlen( $field_suffix ) ) ] = $field_data;
+			}
+		}
+		if ( ! $fields ) continue;
+
+		// Track files..
+		$files_to_upload[] = $fields['file'];
+
+		$payload['LineItems'][] = [
+			'Description' => sprintf(
+				"%s meetup - %s - %s",
+				$message->fields['meetup'],
+				date( 'j M Y', strtotime( $message->fields['date'] ) ),
+				$fields['vendor']
+			),
+			'Quantity' => 1,
+			'UnitAmount' => round( $fields['cost'], 2 ),
+			'AccountCode' => preg_replace( '!^(\S+).*$!', '$1', $fields['category'] ),
+			'Tracking' => $tracking,
+		];
+	}
+
+	$json = xero_api_t( $tenant, 'Invoices', json_encode( $payload ) );
+
+	if ( $json ) {
+		$invoice_id = $json->Invoices[0]->InvoiceID;
+
+		$meta = get_post_meta( $message->id, '_xero_invoice', true ) ?: [];
+		$meta[ $tenant ] = [
+			'id'  => $invoice_id,
+			'org' => get_token()['organisations'][$tenant]['name']
+		];
+		update_post_meta( $message->id, '_xero_invoice', $meta );
+
+		xero_api_t(
+			$tenant,
+			'Invoices/' . $invoice_id . '/History',
+			json_encode([
+				"HistoryRecords" => [
+					[
+						"Details" => sprintf(
+							"Processed by %s, Submitted by %s via %s from %s on %s",
+							wp_get_current_user()->display_name,
+							$message->from,
+							$message->meta['url'],
+							$message->meta['remote_ip'],
+							$message->meta['date'] . ' ' . $message->meta['time']
+						)
+					]
+				]
+			])
+		);
+
+		// Upload files..
+		$upload_details = wp_upload_dir();
+		foreach ( $files_to_upload as $file_url ) {
+			$file_name = str_replace( $upload_details['baseurl'], $upload_details['basedir'], $file_url );
+
+			$upload_name = wp_basename( $file_name );
+			// Remove the Month/secret token from the filename.
+			if ( preg_match( '!^\d{8}-.{8}-!', $upload_name ) ) {
+				$upload_name = substr( $upload_name, 18 );
+			}
+
+			$resp = xero_api_t(
+				$tenant,
+				'Invoices/' . $invoice_id . '/Attachments/' . $upload_name,
+				file_get_contents( $file_name ),
+				[ 'Content-Type'  => $mime = mime_content_type( $file_name )  ]
+			);
+		}
+
+	} else {
+		wp_die( "Invoice Creation Failed." );
+	}
+
+	wp_safe_redirect( $_SERVER['HTTP_REFERER'] );
+	die();
+};
+add_action( 'wp_ajax_xero_create_bill', __NAMESPACE__ . '\create_bill' );
+
+/**
+ * The oAuth callback flow.
+ * 
+ * This has lots of doubled up HTTP queries, but it "works".
+ */
+function oAuth_callback() {
+	if (
+		! isset( $_GET['state'] ) ||
+		( ! isset( $_GET['code'] ) && ! isset( $_GET['error'] ) )
+	) {
+		wp_die( "Invalid Request." );
+	}
+
+	$state_data = json_decode( wp_unslash( $_GET['state'] ) );
+
+	// nonce verify.
+	if ( ! wp_verify_nonce( $state_data->nonce, 'xero' ) ) {
+		wp_die( 'Expired link.' );
+	}
+
+	if ( isset( $_GET['error'] ) ) {
+		if ( !empty( $state_data->back_to ) ) {
+			wp_safe_redirect( $state_data->back_to );
+		} else {
+			wp_safe_redirect( admin_url( 'admin.php?page=flamingo_inbound' ) );
+		}
+
+		die();
+	}
+
+	// Exchange for a token
+	$json = xero_api(
+		'connect/token',
+		[
+			'grant_type'   => 'authorization_code',
+			'code'         => $_GET['code'],
+			'redirect_uri' => admin_url( 'admin-ajax.php?action=xero_oauth_callback' )
+		]
+	);
+
+	$token = false;
+	if ( $json ) {
+		$token = [
+			'access_token'  => $json->access_token,
+			'token_type'    => $json->token_type,
+			'expiration'    => time() + $json->expires_in,
+			'refresh_token' => $json->refresh_token,
+		];
+
+		// Update the tokens now, so it's available for xero_api() below.
+		update_user_meta( get_current_user_id(), '_wpaus_xero', $token );
+	}
+
+	if ( ! empty( $token['access_token'] ) ) {
+		$json = xero_api( 'connections' );
+		if ( $json ) {
+			foreach ( $json as $connection ) {
+				$org_json = xero_api( 'organisation' );
+				if ( $org_json ) {
+					// Name, LegalName, OrganisationID (Tenant ID from above)
+					$token['organisations'] ??= [];
+					foreach ( $org_json->Organisations as $o ) {
+						$token['organisations'][ $o->OrganisationID ] = array(
+							'id'    => $o->OrganisationID,
+							'name'  => $o->Name,
+							'legal' => $o->LegalName,
+						);
+					}
+				}
+			}
+
+			update_user_meta( get_current_user_id(), '_wpaus_xero', $token );
+		}
+	}
+
+	if ( !empty( $state_data->back_to ) ) {
+		wp_safe_redirect( $state_data->back_to );
+	} else {
+		wp_safe_redirect( admin_url( 'admin.php?page=flamingo_inbound' ) );
+	}
+	die();
+}
+add_action( 'wp_ajax_xero_oauth_callback', __NAMESPACE__ . '\oAuth_callback' );


### PR DESCRIPTION
This PR is some work at adding a form which Meetups can request reimbursement through, to ease the burden upon WP Australia organisers while at the same time making it easier for meetups to request reimbursement more often.

Currently there's two methods used by meetups to be reimbursed:
 1. If they have Xero access, create a Expense Report.
 2. Email/SlackDM/pigeon the receipts to an WP Australia rep who then creates a Xero Bill for them.. hopefully same-day but sometimes months later.

This will add a level of public auditing as to where money is being used as well.

What it adds:
 1. Contact Form 7 form, saving into Flamingo. Custom Code adds saving of uploaded Images to Flamingo (Doesn't support that itself..), removing unused receipt fields, and generally making the admin UI nicer.
 2. Flamingo has been extended to add support for multiple statuses (Inbox/Approved/Declined/Paid)
 3. Flamingo has a one-click Xero button to allow pushing of reimbursements to a draft Xero Bill filling in appropriate fields.

Flow for a Meetup organiser:
 1. Go the the reimbursement URL, enter the post password which has been shared with them.
 2. Fill out their Name / Meetup / Date / Receipt (plus who it is, what it is, and how much).
 3. Submit it, and wait for money to pop up in their bank account.

Flow for a WP Australia rep:
 1. Be notified *somehow* (email probably) that there's a new reimbursement request
 2. View the Contact form result in Flamingo, determine if it looks correct (fields/receipts/etc) mark it as Approved (Hopefully Declined will never be used)
 3. (And this part might be a bulk thing done once/twice a month) Go through each Approved item, click the Xero button to create drafts in Xero.
 4. Open Xero (through the Invoice links on the reimbursement requests) make sure all the fields are right and the correct metadata is set for tracking. Mark it as Approved/Awaiting Payment
 5. Open Westpac, create payment request.
 6. (Another WP Australia Rep..) Mark Westpac payments as released as they go through each reimbursement request and mark them as Paid once they've validated that PersonA did it right
7. (Another WP Australia Rep probably..) Mark the Xero transactions as reconciled a few days after 6 was done. This would probably be done as part of steps 4~6 for the next payments

Future TODOs:
 - Would be great if once a Xero bill was created, that the Flamingo CPT could have it's status updated automatically based on the Xero Bill going through it's Draft -> Awaiting Payment -> Paid statuses.
 - Work out a way to make the public audit log also include sponsors joining/paying/leaving the WP Australia sponsorship program
 - Probably ditch Contact Form 7 and implement it as a 'static' form, still using Flamingo still because that just seems to work. There's nothing we need CF7 for here other than the ease of adding and form validation, by staticising it we'd be able to migrate a bunch of hard-coded lists and bad defaults out (ie. Meetup list could be dynamic, suggest recent meetups, maybe actually list THE meetups rather than Meetup/date (ie. `WordPress Narnia: [East Valley] December Meetup: Talk Title Here`) but that's reliant upon a few other WP Australia things happening first.